### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Sonance
 
+[![Help Contribute to Open Source](https://www.codetriage.com/theadnan/sonance/badges/users.svg)](https://www.codetriage.com/theadnan/sonance)
+
 ![sonanca](https://github.com/TheAdnan/sonance/blob/master/icons/sonance.png?raw=true) __Ambient sounds for your browser__ ![sonanca](https://github.com/TheAdnan/sonance/blob/master/icons/sonance.png?raw=true)
 
 This Firefox Web Extension is the poor man's _Noisli_. This is more of an experimental extension. Feel free to contribute to this project with new ambient sounds, improvements in the code or any other suggestion.


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.